### PR TITLE
fix the `implied_bounds_entailment` lint.

### DIFF
--- a/schema_analysis/src/traits.rs
+++ b/schema_analysis/src/traits.rs
@@ -49,8 +49,8 @@ pub trait CoalesceAny: Coalesce {
     /// Merge `other` into `self`. Trait object is returned if merging was unsuccessful.
     fn coalesce_any<'a>(&mut self, other: Box<dyn Any + 'a>) -> Option<Box<dyn Any>>;
 }
-impl<'a, T: Coalesce + 'a> CoalesceAny for T {
-    fn coalesce_any(&mut self, other: Box<dyn Any + 'a>) -> Option<Box<dyn Any>> {
+impl<T: Coalesce + 'static> CoalesceAny for T {
+    fn coalesce_any<'a>(&mut self, other: Box<dyn Any + 'a>) -> Option<Box<dyn Any>> {
         let other: Self = match other.downcast() {
             Ok(downcasted) => *downcasted,
             Err(not_downcasted) => return Some(not_downcasted),


### PR DESCRIPTION
see https://github.com/rust-lang/rust/issues/105572. Your crate unintentionally relied on a bug in the compiler of Rust itself. This bug is now getting fixed and will be a hard error in a future release.

The issue is that the signature of the impl method differs from the signature of the trait method in a way where the impl would actually have **stronger** requirements for the caller. This could be use to trigger undefined behavior. https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=71fd0f91713510e75174a5cda4da1edc

The impl requires `T: 'static` because `'a` has to outlive `'static` for `Box<dyn Any + 'a>` as `Any` requires `Self: 'static`.

This PR fixes this by adding the `Self: 'static` bound to the impl itself. This bound is required to call `downcast` in `coalesce_any`.

Please ask if there are any questions.